### PR TITLE
Fix Auth error 401

### DIFF
--- a/src/pages/auth/login-page.tsx
+++ b/src/pages/auth/login-page.tsx
@@ -5,7 +5,8 @@ import { useState } from "react";
 import "./auth.css";
 import { loginUser } from "../../store/thunks/authThunks";
 import storage from "../../utils/storage";
-import {  useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
+import { setAuthorizationHeader } from "../../api/client";
 
 const LoginPage = () => {
   const dispatch = useAppDispatch();
@@ -36,8 +37,9 @@ const LoginPage = () => {
     const response = await dispatch(loginUser(form));
     if (loginUser.fulfilled.match(response)) {
       const token = response.payload.token;
+      setAuthorizationHeader(token);
       storage.set("auth", token, rememberUser);
-      navigate("/", {replace: true})
+      navigate("/", { replace: true });
     }
   };
 

--- a/src/store/slices/authSlice.ts
+++ b/src/store/slices/authSlice.ts
@@ -1,6 +1,11 @@
 import { createSlice } from "@reduxjs/toolkit";
 import type { User } from "../../pages/auth/userType";
 import { loginUser, createUser } from "../thunks/authThunks";
+import storage from "../../utils/storage";
+import {
+  removeAuthorizationHeader,
+  setAuthorizationHeader,
+} from "../../api/client";
 
 interface AuthState {
   user: User | null;
@@ -11,7 +16,7 @@ interface AuthState {
 
 const initialState: AuthState = {
   user: null,
-  token: localStorage.getItem("accessToken"),
+  token: storage.get("auth"),
   loading: false,
   error: null,
 };
@@ -23,8 +28,8 @@ const authSlice = createSlice({
     logout: (state) => {
       state.user = null;
       state.token = null;
-      localStorage.removeItem("accessToken");
-      sessionStorage.removeItem("accessToken");
+      storage.remove("auth");
+      removeAuthorizationHeader();
     },
   },
   extraReducers: (builder) => {
@@ -35,7 +40,7 @@ const authSlice = createSlice({
     builder.addCase(loginUser.fulfilled, (state, action) => {
       state.loading = false;
       state.token = action.payload.token;
-      localStorage.setItem("accessToken", action.payload.token)
+      setAuthorizationHeader(action.payload.token);
     });
     builder.addCase(loginUser.rejected, (state, action) => {
       state.loading = false;


### PR DESCRIPTION
Había un error en la página de book-detail (book-page), averiguando el porqué aparecía que era un 401 (no autorizado), buscando la explicación, di con que era un error de persistencia del token. 

Ahora, tras hacer login, se guarda siempre bajo la misma clave y almacena en header de Axios. Al cerrar sesión se borra/limpia. 

De este modo, las peticiones vuelven a llevar el Authorization correcto. 